### PR TITLE
Add variable delay for bots, repopulate draw stack

### DIFF
--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -15,7 +15,7 @@
 
 <script>
 import { mapGetters, mapActions, mapMutations } from 'vuex'
-import { LOCATION } from '../js/GameHelper'
+import { LOCATION, randomIntFromInterval } from '../js/GameHelper'
 import Player from './Player'
 import DrawStack from './DrawStack'
 import PlayedStack from './PlayedStack'
@@ -52,6 +52,9 @@ export default {
 
     startTimer () {
       if (!this.timerStarted) {
+        if (this.currentPlayer.type === 'cpu') {
+          this.randomBotMoveTime = randomIntFromInterval(5, 10)
+        }
         this.timerStarted = true
         this.timerInterval = setInterval(this.tickTimer, 1000)
         this.resetTimer()
@@ -71,8 +74,8 @@ export default {
         this.outOfTime()
         return
       }
-      if (this.timerSeconds === 10) {
-        // bot makes a move when timer is at 10s
+      if (this.timerSeconds === this.randomBotMoveTime) {
+        // bot makes a move when timer is equal to randomBotMoveTime
         this.processBot()
         return
       }
@@ -90,15 +93,15 @@ export default {
 
     outOfTime () {
       this.stopTimer()
-      this.drawCardAction(this.currentPlayer)
-      console.log('Out of time! Drawing card from deck...')
+      this.drawCardAction(this.currentPlayer.id)
+      console.log('Out of time!')
       this.endTurn()
     },
 
     processBot () {
       if (this.currentPlayer.type === 'cpu') {
         this.stopTimer()
-        this.changeCpuBoardAction(this.currentPlayer)
+        this.changeCpuBoardAction(this.currentPlayer.id)
         this.endTurn()
       }
     }
@@ -115,7 +118,8 @@ export default {
       MAX_TIME: 15,
       timerSeconds: this.MAX_TIME,
       timerStarted: false,
-      timerInterval: null
+      timerInterval: null,
+      randomBotMoveTime: 10
     }
   }
 }

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -27,15 +27,25 @@ export default {
     PlayedStack
   },
 
+  watch: {
+    currentTurnStatus: function (val, oldVal) {
+      if (val === false && oldVal === true) {
+        this.turnStatusChange()
+      }
+    }
+  },
+
   computed: {
     ...mapGetters([
       'players',
       'currentPlayer',
-      'lastColour'
+      'lastColour',
+      'currentTurnStatus'
     ])
   },
 
   mounted: function () {
+    // this.initPlayers()
     this.startTimer()
   },
 
@@ -47,11 +57,13 @@ export default {
 
     ...mapMutations([
       'switchPlayer',
-      'changeCpuBoardAction'
+      'changeCpuBoardAction',
+      'startCurrentTurn'
     ]),
 
     startTimer () {
       if (!this.timerStarted) {
+        this.startCurrentTurn()
         if (this.currentPlayer.type === 'cpu') {
           this.randomBotMoveTime = randomIntFromInterval(5, 10)
         }
@@ -102,8 +114,13 @@ export default {
       if (this.currentPlayer.type === 'cpu') {
         this.stopTimer()
         this.changeCpuBoardAction(this.currentPlayer.id)
-        this.endTurn()
+        // this.endTurn()
       }
+    },
+
+    turnStatusChange () {
+      this.stopTimer()
+      this.endTurn()
     }
   },
 

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -13,7 +13,7 @@
 <script>
 import Card from './Card'
 import { LOCATION, SECONDARY, COLOR } from '../js/GameHelper'
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters, mapActions, mapMutations } from 'vuex'
 
 export default {
   props: {
@@ -69,6 +69,10 @@ export default {
       'changeColourAction'
     ]),
 
+    ...mapMutations([
+      'endCurrentTurn'
+    ]),
+
     drawCard: function () {
       // passing a turn = drawing a card
       this.drawCardAction(this.playerNumber)
@@ -84,12 +88,14 @@ export default {
           console.log(this.playerNumber + ' played card ' + hand[i].color + '-' + hand[i].secondary)
           this.processCardEffect(hand[i])
           this.playCardAction([hand[i], this.playerNumber])
+          this.endCurrentTurn()
           return
         }
       }
       // No valid moves for the bot
       console.log('No valid moves for bot, drawing card')
       this.drawCard()
+      this.endCurrentTurn()
     },
 
     playCard: function (card) {
@@ -97,6 +103,8 @@ export default {
         console.log('you played card ' + card.color + '-' + card.secondary)
         this.processCardEffect(card)
         this.playCardAction([card, this.playerNumber])
+        this.endCurrentTurn()
+        console.log('ending current turn')
       } else {
         console.log('illegal move')
       }

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -94,6 +94,7 @@ export default {
 
     playCard: function (card) {
       if (this.checkLegalMove(card)) {
+        console.log('you played card ' + card.color + '-' + card.secondary)
         this.processCardEffect(card)
         this.playCardAction([card, this.playerNumber])
       } else {

--- a/src/js/GameHelper.js
+++ b/src/js/GameHelper.js
@@ -13,6 +13,14 @@ export const shuffleArray = function (array) {
   return array
 }
 
+/**
+ * Generates a random integer between two integers.
+ * http://stackoverflow.com/questions/4959975/generate-random-number-between-two-numbers-in-javascript
+ */
+export const randomIntFromInterval = function (min, max) {
+  return Math.floor(Math.random() * (max - min + 1) + min)
+}
+
 export const SECONDARY = {
   MOON: 'moon',
   STAR: 'star',

--- a/src/vuex/actions.js
+++ b/src/vuex/actions.js
@@ -34,7 +34,7 @@ export default {
       })
     }
 
-    commit('shufflePlayers')
+    // commit('shufflePlayers')
 
     commit('dealCards')
 
@@ -45,12 +45,13 @@ export default {
     commit('playCard', state.game.deck[28])
   },
 
-  playCardAction: function ({commit}, [card, player]) {
+  playCardAction: function ({commit}, [card, playerNumber]) {
     commit('playCard', card)
   },
 
-  drawCardAction: function ({commit}, player) {
-    commit('drawCard', player)
+  drawCardAction: function ({commit}, playerNumber) {
+    commit('drawCard', playerNumber)
+    commit('repopulateDrawStack')
   },
 
   switchDirectionAction: function ({commit}) {

--- a/src/vuex/actions.js
+++ b/src/vuex/actions.js
@@ -14,13 +14,14 @@ export default {
           {
             id: PLAYER_LOCATION[0],
             type: 'human',
-            timeRemaining: 10
+            currentTurn: false
           }
         ],
         lastCardPlayed: null,
         specialAttackStack: 0,
         statusMessage: '',
-        cpuBoardAction: ''
+        cpuBoardAction: '',
+        currentColor: ''
       }
     })
   },
@@ -30,7 +31,7 @@ export default {
       commit('addPlayer', {
         id: PLAYER_LOCATION[i],
         type: 'cpu',
-        timeRemaining: 0
+        currentTurn: false
       })
     }
 

--- a/src/vuex/getters.js
+++ b/src/vuex/getters.js
@@ -14,5 +14,6 @@ export default {
   lastCardPlayed: state => state.game.lastCardPlayed,
   attackStatus: state => state.game.specialAttackStack,
   cpuBoardAction: state => state.game.cpuBoardAction,
+  currentTurnStatus: state => state.game.players[0].currentTurn,
   lastColour: state => state.game.currentColour
 }

--- a/src/vuex/mutations.js
+++ b/src/vuex/mutations.js
@@ -16,6 +16,7 @@ export default {
     state.game.specialAttackStack = resetState.game.specialAttackStack
     state.game.statusMessage = resetState.game.statusMessage
     state.game.cpuBoardAction = resetState.game.cpuBoardAction
+    state.game.currentColour = resetState.game.currentColour
   },
 
   /*
@@ -52,6 +53,14 @@ export default {
     state.game.players.push(player)
   },
 
+  startCurrentTurn (state) {
+    state.game.players[0].currentTurn = true
+  },
+
+  endCurrentTurn (state) {
+    state.game.players[0].currentTurn = false
+  },
+
   playCard (state, card) {
     state.game.deck.find(deckCard => deckCard.color === card.color && deckCard.secondary === card.secondary).location = LOCATION.PLAYED_STACK
     state.game.lastCardPlayed = card
@@ -64,13 +73,13 @@ export default {
       for (var i = 0; i < state.game.specialAttackStack - 1; i++) {
         var spCard = state.game.deck.find(deckCard => deckCard.location === LOCATION.DRAW_STACK)
         spCard.location = playerNumber
-        console.log(playerNumber + ' special attack stack drawn card ' + spCard.color + '-' + spCard.secondary)
+        console.log(playerNumber + ' special attack stack drew card ' + spCard.color + '-' + spCard.secondary)
       }
       state.game.specialAttackStack = 0
     }
     var card = state.game.deck.find(deckCard => deckCard.location === LOCATION.DRAW_STACK)
     card.location = playerNumber
-    console.log(playerNumber + ' drawn card ' + card.color + '-' + card.secondary)
+    console.log(playerNumber + ' drew card ' + card.color + '-' + card.secondary)
   },
 
   switchDirection (state) {

--- a/src/vuex/mutations.js
+++ b/src/vuex/mutations.js
@@ -55,6 +55,8 @@ export default {
   playCard (state, card) {
     state.game.deck.find(deckCard => deckCard.color === card.color && deckCard.secondary === card.secondary).location = LOCATION.PLAYED_STACK
     state.game.lastCardPlayed = card
+
+    state.game.lastCardPlayed.color = state.game.currentColour
   },
 
   drawCard (state, playerNumber) {

--- a/src/vuex/mutations.js
+++ b/src/vuex/mutations.js
@@ -67,6 +67,16 @@ export default {
   },
 
   drawCard (state, playerNumber) {
+    function repopulateDrawStack () {
+      var drawStack = state.game.deck.filter(card => card.location === LOCATION.DRAW_STACK)
+      if (drawStack.length === 0) {
+        var playedStack = state.game.deck.filter(card => card.location === LOCATION.PLAYED_STACK)
+        for (var i = 0; i < playedStack.length; i++) {
+          playedStack[i].location = LOCATION.DRAW_STACK
+        }
+      }
+    }
+
     // If there are attacks stacked, then drawing means that the player has lost the attack
     if (state.game.specialAttackStack) {
       // draw cards equal to the value of the stack and then reset the stack value
@@ -74,11 +84,14 @@ export default {
         var spCard = state.game.deck.find(deckCard => deckCard.location === LOCATION.DRAW_STACK)
         spCard.location = playerNumber
         console.log(playerNumber + ' special attack stack drew card ' + spCard.color + '-' + spCard.secondary)
+        repopulateDrawStack()
       }
       state.game.specialAttackStack = 0
     }
+
     var card = state.game.deck.find(deckCard => deckCard.location === LOCATION.DRAW_STACK)
     card.location = playerNumber
+    repopulateDrawStack()
     console.log(playerNumber + ' drew card ' + card.color + '-' + card.secondary)
   },
 

--- a/src/vuex/mutations.js
+++ b/src/vuex/mutations.js
@@ -57,17 +57,20 @@ export default {
     state.game.lastCardPlayed = card
   },
 
-  drawCard (state, player) {
-    // If there are attacks stacked, then drawing means that thie player has lost the attack
+  drawCard (state, playerNumber) {
+    // If there are attacks stacked, then drawing means that the player has lost the attack
     if (state.game.specialAttackStack) {
       // draw cards equal to the value of the stack and then reset the stack value
       for (var i = 0; i < state.game.specialAttackStack - 1; i++) {
-        state.game.deck.find(deckCard => deckCard.location === LOCATION.DRAW_STACK).location = player.id
+        var spCard = state.game.deck.find(deckCard => deckCard.location === LOCATION.DRAW_STACK)
+        spCard.location = playerNumber
+        console.log(playerNumber + ' special attack stack drawn card ' + spCard.color + '-' + spCard.secondary)
       }
       state.game.specialAttackStack = 0
     }
-
-    state.game.deck.find(deckCard => deckCard.location === LOCATION.DRAW_STACK).location = player.id
+    var card = state.game.deck.find(deckCard => deckCard.location === LOCATION.DRAW_STACK)
+    card.location = playerNumber
+    console.log(playerNumber + ' drawn card ' + card.color + '-' + card.secondary)
   },
 
   switchDirection (state) {
@@ -91,7 +94,17 @@ export default {
     state.game.gameState = message
   },
 
-  changeCpuBoardAction (state, player) {
-    state.game.cpuBoardAction = player.id
+  changeCpuBoardAction (state, playerNumber) {
+    state.game.cpuBoardAction = playerNumber
+  },
+
+  repopulateDrawStack (state) {
+    var drawStack = state.game.deck.filter(card => card.location === LOCATION.DRAW_STACK)
+    if (drawStack.length === 0) {
+      var playedStack = state.game.deck.filter(card => card.location === LOCATION.PLAYED_STACK)
+      for (var i = 0; i < playedStack.length; i++) {
+        playedStack[i].location = LOCATION.DRAW_STACK
+      }
+    }
   }
 }


### PR DESCRIPTION
Also fixes card drawing and adds better debug messages.

List of changes:

- Variable delay for bots
- Repopulate draw stack (not shuffled yet)
- Fix card drawing issue where it assigned location as undefined
- Better debug messages
- Turn progression for Player 1
- Fix bug where repopulating the draw stack fails when drawing multiple cards (special attack)

To-do:
- Only permit Player 1 to play a card when it's P1's turn